### PR TITLE
inference error

### DIFF
--- a/lib/src/engine/transport/polling_transport.dart
+++ b/lib/src/engine/transport/polling_transport.dart
@@ -260,7 +260,7 @@ class PollingTransport extends Transport {
     var contentType =
         isString ? 'text/plain; charset=UTF-8' : 'application/octet-stream';
 
-    final headers = {'Content-Type': contentType};
+    final headers = <String, dynamic>{'Content-Type': contentType};
 
     var respond = (data) {
       headers[HttpHeaders.contentLengthHeader] =


### PR DESCRIPTION
dart takes the edited line as Map<String, String>, then it throws an exception because it tries to add an int. 
Setting it manually to <String, dynamic> fixes it